### PR TITLE
Apply initial shift only if target is above 50MW

### DIFF
--- a/gridcapa-cse-valid-app/src/main/java/com/farao_community/farao/cse_valid/app/service/ExportCornerComputationService.java
+++ b/gridcapa-cse-valid-app/src/main/java/com/farao_community/farao/cse_valid/app/service/ExportCornerComputationService.java
@@ -46,6 +46,7 @@ import static com.farao_community.farao.cse_valid.app.Constants.ERROR_MSG_MISSIN
 @Service
 public class ExportCornerComputationService {
 
+    private static final int MINIMUM_SHIFT_VALUE = 50;
     private final ComputationService computationService;
     private final DichotomyRunner dichotomyRunner;
     private final FileImporter fileImporter;
@@ -89,12 +90,14 @@ public class ExportCornerComputationService {
 
                 String cgmUrl = cseValidRequest.getCgm().getUrl();
                 Network network = fileImporter.importNetwork(cgmUrl);
-                String glskUrl = cseValidRequest.getGlsk().getUrl();
                 ProcessType processType = cseValidRequest.getProcessType();
-                NetworkShifter networkShifter = cseValidNetworkShifterProvider.getNetworkShifterForExportCornerWithAllCountries(timestampWrapper, network, glskUrl, processType);
                 double shiftValue = computeShiftValue(timestampWrapper);
 
-                computationService.shiftNetwork(shiftValue, network, networkShifter);
+                if (shiftValue >= MINIMUM_SHIFT_VALUE) {
+                    String glskUrl = cseValidRequest.getGlsk().getUrl();
+                    NetworkShifter networkShifter = cseValidNetworkShifterProvider.getNetworkShifterForExportCornerWithAllCountries(timestampWrapper, network, glskUrl, processType);
+                    computationService.shiftNetwork(shiftValue, network, networkShifter);
+                }
 
                 OffsetDateTime processTargetDateTime = cseValidRequest.getTimestamp();
                 String raoParametersURL = fileExporter.saveRaoParameters(processTargetDateTime, processType);

--- a/gridcapa-cse-valid-app/src/main/java/com/farao_community/farao/cse_valid/app/service/FullImportComputationService.java
+++ b/gridcapa-cse-valid-app/src/main/java/com/farao_community/farao/cse_valid/app/service/FullImportComputationService.java
@@ -44,6 +44,7 @@ import static com.farao_community.farao.cse_valid.app.Constants.ERROR_MSG_MISSIN
 @Service
 public class FullImportComputationService {
 
+    private static final int MINIMUM_SHIFT_VALUE = 50;
     private final ComputationService computationService;
     private final DichotomyRunner dichotomyRunner;
     private final FileImporter fileImporter;
@@ -83,12 +84,14 @@ public class FullImportComputationService {
 
                 String cgmUrl = cseValidRequest.getCgm().getUrl();
                 Network network = fileImporter.importNetwork(cgmUrl);
-                String glskUrl = cseValidRequest.getGlsk().getUrl();
                 ProcessType processType = cseValidRequest.getProcessType();
-                NetworkShifter networkShifter = cseValidNetworkShifterProvider.getNetworkShifterForFullImport(timestampWrapper, network, glskUrl, processType);
                 double shiftValue = computeShiftValue(timestampWrapper, network);
 
-                computationService.shiftNetwork(shiftValue, network, networkShifter);
+                if (shiftValue >= MINIMUM_SHIFT_VALUE) {
+                    String glskUrl = cseValidRequest.getGlsk().getUrl();
+                    NetworkShifter networkShifter = cseValidNetworkShifterProvider.getNetworkShifterForFullImport(timestampWrapper, network, glskUrl, processType);
+                    computationService.shiftNetwork(shiftValue, network, networkShifter);
+                }
 
                 String cracUrl = cseValidRequest.getImportCrac().getUrl();
                 CseCracCreationContext cracCreationContext = fileImporter.importCracCreationContext(cracUrl, network);

--- a/gridcapa-cse-valid-app/src/test/java/com/farao_community/farao/cse_valid/app/utils/TimestampTestData.java
+++ b/gridcapa-cse-valid-app/src/test/java/com/farao_community/farao/cse_valid/app/utils/TimestampTestData.java
@@ -174,11 +174,11 @@ public final class TimestampTestData {
         timestamp.setTime(timeValue);
 
         QuantityType mniiValue = new QuantityType();
-        mniiValue.setV(BigDecimal.TEN);
+        mniiValue.setV(BigDecimal.valueOf(100L));
         timestamp.setMNII(mniiValue);
 
         QuantityType mibniiValue = new QuantityType();
-        mibniiValue.setV(BigDecimal.valueOf(7.0));
+        mibniiValue.setV(BigDecimal.valueOf(57.0));
         timestamp.setMiBNII(mibniiValue);
 
         QuantityType antcfinalValue = new QuantityType();
@@ -380,7 +380,7 @@ public final class TimestampTestData {
         timestamp.setTime(timeValue);
 
         QuantityType miecValue = new QuantityType();
-        miecValue.setV(BigDecimal.TEN);
+        miecValue.setV(BigDecimal.valueOf(100L));
         timestamp.setMIEC(miecValue);
 
         QuantityType mibiecValue = new QuantityType();
@@ -412,7 +412,7 @@ public final class TimestampTestData {
         timestamp.setTime(timeValue);
 
         QuantityType miecValue = new QuantityType();
-        miecValue.setV(BigDecimal.TEN);
+        miecValue.setV(BigDecimal.valueOf(100L));
         timestamp.setMIEC(miecValue);
 
         QuantityType mibiecValue = new QuantityType();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a minimum shift value for network operations, enhancing control over execution conditions.
  
- **Bug Fixes**
	- Improved logic to prevent unnecessary network shifts based on specific conditions.

- **Tests**
	- Added new test cases to verify that network shifts do not occur under certain geographical conditions.
	- Enhanced existing tests to ensure correct behavior in timestamp computations.

- **Chores**
	- Updated test data values to reflect new expected outcomes in specific scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->